### PR TITLE
Fix : Prevent new_balance amount from rounding up in transactionBatch.py

### DIFF
--- a/transactions/transactionBatch.py
+++ b/transactions/transactionBatch.py
@@ -32,11 +32,7 @@ async def sign_and_push_transactions(transactions):
             id = transaction.get("id")
             # print("id", id)
             new_balance = transaction.get("new_balance")
-            amounts = str(
-                Decimal(new_balance).quantize(
-                    Decimal("0.00000001"), rounding=ROUND_DOWN
-                )
-            )
+            amounts = "{:.8f}".format(float(new_balance))
 
             message = ""
             try:


### PR DESCRIPTION
Fix Description 

new_balance = 0.30626981
amounts = str(
                Decimal(new_balance).quantize(
                    Decimal("0.00000000"), rounding=ROUND_DOWN
                )
            )
# output : 0.30626980
amounts = "{:.8f}".format(float(new_balance))
# output : 0.30626981